### PR TITLE
Add support for PWA icon

### DIFF
--- a/class-pwa-manifest.php
+++ b/class-pwa-manifest.php
@@ -29,7 +29,7 @@ class PWA_Manifest {
 		}
 
 		// Add short name which is required by the PWA standards.
-		$manifest['short_name'] = get_bloginfo( 'name' );
+		$manifest['short_name'] = substr( get_bloginfo( 'name' ), 0, 12 );
 
 		// Get the PWA icon id first.
 		$icon_id = get_theme_mod( 'rpe_pwa_icon' );

--- a/class-pwa-manifest.php
+++ b/class-pwa-manifest.php
@@ -35,14 +35,14 @@ class PWA_Manifest {
 		$icon_id = get_theme_mod( 'rpe_pwa_icon' );
 		// Get the site icon id if PWA icon is not set.
 		$icon_id = ! empty( $icon_id ) ? $icon_id : get_option( 'site_icon' );
-		$icons = array();
+		$icons   = array();
 		if ( ! empty( $icon_id ) ) {
 			$icon_sizes = [ '72', '96', '128', '144', '152', '192', '384', '512' ];
 
 			// Add icons with different sizes.
 			foreach ( $icon_sizes as $icon_size ) {
 				$image_size_label = sprintf( 'pwa-icon-%1$d', $icon_size );
-				$icon = wp_get_attachment_image_src( absint( $icon_id ), $image_size_label );
+				$icon             = wp_get_attachment_image_src( absint( $icon_id ), $image_size_label );
 				if ( ! empty( $icon ) ) {
 					$icons[] = [
 						'src'   => $icon[0],

--- a/class-pwa-manifest.php
+++ b/class-pwa-manifest.php
@@ -44,8 +44,16 @@ class PWA_Manifest {
 				$image_size_label = sprintf( 'pwa-icon-%1$d', $icon_size );
 				$icon             = wp_get_attachment_image_src( absint( $icon_id ), $image_size_label );
 				if ( ! empty( $icon ) ) {
-					$icons[] = [
-						'src'   => $icon[0],
+					$icon_hook_name = sprintf( 'rtpwa_icon_%d_url', $icon_size );
+
+					/**
+					 * Filters the PWA Icon URL by size.
+					 *
+					 * @param int $icon_url URL of icon.
+					 */
+					$icon_url = apply_filters( $icon_hook_name, $icon[0] );
+					$icons[]  = [
+						'src'   => $icon_url,
 						'sizes' => sprintf( '%1$sx%1$s', $icon_size ),
 						'type'  => get_post_mime_type( $icon_id ),
 					];

--- a/class-pwa-manifest.php
+++ b/class-pwa-manifest.php
@@ -27,13 +27,32 @@ class PWA_Manifest {
 		if ( empty( $manifest ) || ! is_array( $manifest ) ) {
 			return $manifest;
 		}
-		$icon_sizes = [ '72', '96', '128', '144', '152', '192', '384', '512' ];
-		foreach ( $icon_sizes as $icon_size ) {
-			$manifest['icons'][] = [
-				'src'   => sprintf( '%1$s/assets/img/icon-%2$sx%2$s.png', get_template_directory_uri(), $icon_size ),
-				'sizes' => sprintf( '%1$sx%1$s', $icon_size ),
-			];
+
+		// Add short name which is required by the PWA standards.
+		$manifest['short_name'] = get_bloginfo( 'name' );
+
+		// Get the PWA icon id first.
+		$icon_id = get_theme_mod( 'rpe_pwa_icon' );
+		// Get the site icon id if PWA icon is not set.
+		$icon_id = ! empty( $icon_id ) ? $icon_id : get_option( 'site_icon' );
+		$icons = array();
+		if ( ! empty( $icon_id ) ) {
+			$icon_sizes = [ '72', '96', '128', '144', '152', '192', '384', '512' ];
+
+			// Add icons with different sizes.
+			foreach ( $icon_sizes as $icon_size ) {
+				$image_size_label = sprintf( 'pwa-icon-%1$d', $icon_size );
+				$icon = wp_get_attachment_image_src( absint( $icon_id ), $image_size_label );
+				if ( ! empty( $icon ) ) {
+					$icons[] = [
+						'src'   => $icon[0],
+						'sizes' => sprintf( '%1$sx%1$s', $icon_size ),
+						'type'  => get_post_mime_type( $icon_id ),
+					];
+				}
+			}
 		}
+		$manifest['icons']   = $icons;
 		$manifest['display'] = 'standalone';
 		return $manifest;
 	}

--- a/class-pwa-manifest.php
+++ b/class-pwa-manifest.php
@@ -35,7 +35,7 @@ class PWA_Manifest {
 		$icon_id = get_theme_mod( 'rpe_pwa_icon' );
 		// Get the site icon id if PWA icon is not set.
 		$icon_id = ! empty( $icon_id ) ? $icon_id : get_option( 'site_icon' );
-		$icons   = array();
+		$icons   = [];
 		if ( ! empty( $icon_id ) ) {
 			$icon_sizes = [ '72', '96', '128', '144', '152', '192', '384', '512' ];
 

--- a/rt-pwa-extensions.php
+++ b/rt-pwa-extensions.php
@@ -110,7 +110,7 @@ add_action(
 	}
 );
 
-// Regenerate all thumbnail of the current site id image with new sizes.
+// Regenerate all thumbnail for the current site icon image with new sizes.
 register_activation_hook(
 	__FILE__,
 	function() {

--- a/rt-pwa-extensions.php
+++ b/rt-pwa-extensions.php
@@ -42,16 +42,16 @@ add_action(
 	function( \WP_Service_Worker_Scripts $scripts ) {
 		$scripts->caching_routes()->register(
 			'/wp-content/.*\.(?:png|gif|jpg|jpeg|svg|webp)(\?.*)?$',
-			array(
+			[
 				'strategy'  => WP_Service_Worker_Caching_Routes::STRATEGY_CACHE_FIRST,
 				'cacheName' => 'images',
-				'plugins'   => array(
-					'expiration' => array(
+				'plugins'   => [
+					'expiration' => [
 						'maxEntries'    => 50,
 						'maxAgeSeconds' => 60 * 60 * 24,
-					),
-				),
-			)
+					],
+				],
+			]
 		);
 	}
 );
@@ -86,16 +86,16 @@ add_action(
 	function( $wp_customize ) {
 		$wp_customize->add_setting(
 			'rpe_pwa_icon',
-			array(
+			[
 				'transport' => 'postMessage',
-			)
+			]
 		);
 
 		$wp_customize->add_control(
 			new WP_Customize_Cropped_Image_Control(
 				$wp_customize,
 				'cropped_image',
-				array(
+				[
 					'section'     => 'title_tagline',
 					'label'       => __( 'PWA Icon' ),
 					'flex_width'  => true, // Allow any width, making the specified value recommended.
@@ -104,7 +104,7 @@ add_action(
 					'height'      => 512,
 					'priority'    => 16,
 					'settings'    => 'rpe_pwa_icon',
-				)
+				]
 			)
 		);
 	}

--- a/rt-pwa-extensions.php
+++ b/rt-pwa-extensions.php
@@ -81,33 +81,48 @@ foreach ( $icon_sizes as $size ) {
 }
 
 // Add Customizer settings to select PWA Icon.
-add_action( 'customize_register', function( $wp_customize ) {
-	$wp_customize->add_setting( 'rpe_pwa_icon' , array(
-			'transport' => 'postMessage',
-	) );
+add_action(
+	'customize_register',
+	function( $wp_customize ) {
+		$wp_customize->add_setting(
+			'rpe_pwa_icon',
+			array(
+				'transport' => 'postMessage',
+			)
+		);
 
-	$wp_customize->add_control( new WP_Customize_Cropped_Image_Control( $wp_customize, 'cropped_image', array(
-			'section'     => 'title_tagline',
-			'label'       => __( 'PWA Icon' ),
-			'flex_width'  => true, // Allow any width, making the specified value recommended.
-			'flex_height' => true, // Require the resulting image to be exactly as tall as the height attribute.
-			'width'       => 512,
-			'height'      => 512,
-			'priority'    => 16,
-			'settings'    => 'rpe_pwa_icon',
-	) ) );
-} );
+		$wp_customize->add_control(
+			new WP_Customize_Cropped_Image_Control(
+				$wp_customize,
+				'cropped_image',
+				array(
+					'section'     => 'title_tagline',
+					'label'       => __( 'PWA Icon' ),
+					'flex_width'  => true, // Allow any width, making the specified value recommended.
+					'flex_height' => true, // Require the resulting image to be exactly as tall as the height attribute.
+					'width'       => 512,
+					'height'      => 512,
+					'priority'    => 16,
+					'settings'    => 'rpe_pwa_icon',
+				)
+			)
+		);
+	}
+);
 
 // Regenerate all thumbnail of the current site id image with new sizes.
-register_activation_hook( __FILE__, function() {
+register_activation_hook(
+	__FILE__,
+	function() {
 
-	$site_icon_id = get_option( 'site_icon' );
+		$site_icon_id = get_option( 'site_icon' );
 
-	if ( ! empty( $site_icon_id ) ) {
-		require_once( ABSPATH . 'wp-admin/includes/image.php' );
-		require_once( ABSPATH . 'wp-includes/pluggable.php' );
-		$metadata = wp_generate_attachment_metadata( $site_icon_id, get_attached_file( $site_icon_id ) );
-		wp_update_attachment_metadata( $site_icon_id, $metadata );
+		if ( ! empty( $site_icon_id ) ) {
+			require_once ABSPATH . 'wp-admin/includes/image.php';
+			require_once ABSPATH . 'wp-includes/pluggable.php';
+			$metadata = wp_generate_attachment_metadata( $site_icon_id, get_attached_file( $site_icon_id ) );
+			wp_update_attachment_metadata( $site_icon_id, $metadata );
+		}
+
 	}
-
-} );
+);


### PR DESCRIPTION
 1. Add customizer setting to upload PWA icon.
 2. Use 8 different sizes for PWA icon.
 3. Add site icon as fallback for PWA icon.
 4. Add short_name field in manifest.

Issue:#1

![image](https://user-images.githubusercontent.com/6830654/64868799-aa5c7780-d65d-11e9-9f69-26fbee16b3c8.png)
