### PR TITLE
WIP: Set self.__WB_DISABLE_DEV_LOGS constant to true

### DIFF
--- a/rt-pwa-extensions.php
+++ b/rt-pwa-extensions.php
@@ -69,3 +69,23 @@ add_filter(
 		return $headers;
 	}
 );
+
+/**
+ * Disables WorkBox dev logs.
+ *
+ * @param object $scripts
+ *
+ * @return void
+ */
+function disable_workbox_logs( $scripts ) {
+	$scripts->register(
+		'disable_workbox_logs',
+		array(
+			'src' => function() {
+				return 'self.__WB_DISABLE_DEV_LOGS = true;';
+			},
+		)
+	);
+}
+
+add_action( 'wp_front_service_worker', 'disable_workbox_logs' );


### PR DESCRIPTION
Fixes #5 
Note: The logs will only get disabled if the Workbox version is >=5.0.0. Currently, the alpha version of PWA plugin is using workbox version 5.0.0 and it is tested on the alpha version of the plugin