### PR TITLE
Fix offline-form submit service worker script conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ An extension to [PWA](https://wordpress.org/plugins/pwa/) to enable `add to home
 - Submit gravity form even if you are offline. The plugin will send form response once you get back online.
 - The offline form submission will only work for the routes added to the plugin settings page.
 - If no routes are set the offline form submission script will not be enqueued.
-- Add form routes to enable offline form submission in the plugin settings page.
 e.g Enable offline form submission with following settings for the forms available on routes `example.com/contact` and `example.com/feedback`
 ```
 /contact

--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ An extension to [PWA](https://wordpress.org/plugins/pwa/) to enable `add to home
 - Offline reading by caching assets and pages.
 
 ### Offline Form Submission.
-- Submit gravity form even if you are offline. Plugin will send form response once you get back online.
-- Add form routes to enable offline form submission in plugin settings page.
+- Submit gravity form even if you are offline. The plugin will send form response once you get back online.
+- The offline form submission will only work for the routes added to the plugin settings page.
+- If no routes are set the offline form submission script will not be enqueued.
+- Add form routes to enable offline form submission in the plugin settings page.
 e.g Enable offline form submission with following settings for the forms available on routes `example.com/contact` and `example.com/feedback`
 ```
 /contact
 /feedback
 ```
- 
-
 ## Integration with izooto plugin.
 
 - Registers izooto service worker using `wp_front_service_worker` hook to main service worker file

--- a/inc/classes/class-manifest.php
+++ b/inc/classes/class-manifest.php
@@ -38,6 +38,8 @@ class Manifest {
 			return $manifest;
 		}
 
+		$manifest['short_name'] = $manifest['name'];
+
 		$icon_sizes = array( '72', '96', '128', '144', '152', '192', '384', '512' );
 
 		foreach ( $icon_sizes as $icon_size ) {

--- a/inc/classes/class-offline-form.php
+++ b/inc/classes/class-offline-form.php
@@ -62,7 +62,9 @@ class Offline_Form {
 			$scripts->register(
 				'offline-form-submit', // Handle.
 				array(
-					'src'  => array( $this, 'get_offline_form_script' ),
+					'src'  => function() use ( $offline_form_sw_script ) {
+						return $offline_form_sw_script;
+					},
 					'deps' => array(), // Dependency.
 				)
 			);

--- a/inc/classes/class-offline-form.php
+++ b/inc/classes/class-offline-form.php
@@ -56,13 +56,17 @@ class Offline_Form {
 	 */
 	public function offline_form_service_worker( $scripts ) {
 
-		$scripts->register(
-			'offline-form-submit', // Handle.
-			array(
-				'src'  => array( $this, 'get_offline_form_script' ),
-				'deps' => array(), // Dependency.
-			)
-		);
+		$offline_form_sw_script = $this->get_offline_form_script();
+
+		if ( false !== $offline_form_sw_script ) {
+			$scripts->register(
+				'offline-form-submit', // Handle.
+				array(
+					'src'  => array( $this, 'get_offline_form_script' ),
+					'deps' => array(), // Dependency.
+				)
+			);
+		}
 
 	}
 
@@ -76,6 +80,12 @@ class Offline_Form {
 		$sw_script = preg_replace( '#/\*\s*global.+?\*/#', '', $sw_script );
 
 		$form_routes_regex = $this->get_form_urls();
+
+		// Bail out if offline form routes are not set.
+		if ( false === $form_routes_regex ) {
+			return false;
+		}
+
 		// Replace with error messages | offline template url |error template url | form routes.
 		$sw_script = str_replace(
 			array(
@@ -105,9 +115,8 @@ class Offline_Form {
 		$string      = '';
 		$form_routes = get_option( 'rt_pwa_extension_options' );
 		if ( empty( $form_routes ) || ctype_space( $form_routes ) ) {
-			// Generate random string if no URLs specified.
-			// Random string ensures that no URL match.
-			$string = wp_generate_password( '30', false, false );
+			// Return false if no offline form routes are set.
+			$string = false;
 		} else {
 			$routes = explode( PHP_EOL, $form_routes );
 			// Create regex string like ( '/contact|/form|/gravity-form' ).

--- a/inc/classes/integration/class-izooto.php
+++ b/inc/classes/integration/class-izooto.php
@@ -58,6 +58,11 @@ class Izooto {
 					$obj = new \Init();
 					$opfunction = $obj->iz_get_option( 'izooto-settings' );
 
+					// Bail out if izooto not configured correctly.
+					if ( empty( $opfunction['sw'] ) ) {
+						return;
+					}
+
 					return sprintf( 'var izCacheVer = 1; importScripts("%1$s");', esc_url_raw( 'https://' . $opfunction['sw'] ) );
 				},
 			)

--- a/tests/inc/test-class-manifest.php
+++ b/tests/inc/test-class-manifest.php
@@ -44,6 +44,7 @@ class Test_Manifest extends \WP_UnitTestCase {
 	public function test_filter_web_app_manifest() {
 
 		// Empty manifest.
+
 		$this->assertEmpty( $this->_instance->filter_web_app_manifest( '' ) );
 
 		$icon_sizes = [ '72', '96', '128', '144', '152', '192', '384', '512' ];
@@ -57,13 +58,16 @@ class Test_Manifest extends \WP_UnitTestCase {
 
 		}
 		$expected_data = [
-			'test_key' => 'test_value',
-			'icons'    => $icons,
-			'display'  => 'standalone',
+			'test_key'   => 'test_value',
+			'icons'      => $icons,
+			'display'    => 'standalone',
+			'name' => 'test site',
+			'short_name' => 'test site',
 		];
 
 		$arg = [
 			'test_key' => 'test_value',
+			'name'     => 'test site',
 		];
 
 		$this->assertEquals( $expected_data, $this->_instance->filter_web_app_manifest( $arg ) );

--- a/tests/inc/test-class-offline-form.php
+++ b/tests/inc/test-class-offline-form.php
@@ -74,9 +74,18 @@ class Test_Offline_Form extends \WP_UnitTestCase {
 	 */
 	public function test_offline_form_service_worker() {
 
-		$this->_instance->offline_form_service_worker( $this->scripts );
+		$old_option = get_option( 'rt_pwa_extension_options' );
 
+		$this->_instance->offline_form_service_worker( $this->scripts );
+		$this->assertArrayNotHasKey( 'offline-form-submit', $this->scripts->registered );
+
+		$option = 'test1' . PHP_EOL . 'test2' . PHP_EOL . 'test3';
+		update_option( 'rt_pwa_extension_options', $option );
+
+		$this->_instance->offline_form_service_worker( $this->scripts );
 		$this->assertArrayHasKey( 'offline-form-submit', $this->scripts->registered );
+
+		update_option( 'rt_pwa_extension_options', $old_option );
 	}
 
 	/**
@@ -85,7 +94,7 @@ class Test_Offline_Form extends \WP_UnitTestCase {
 	public function test_get_form_urls() {
 
 		// Testing Empty Routes
-		$this->assertNotEmpty( Utility::invoke_method( $this->_instance, 'get_form_urls' ) );
+		$this->assertFalse( Utility::invoke_method( $this->_instance, 'get_form_urls' ) );
 
 		// Testing else condition
 		$option = 'test1 abc' . PHP_EOL . 'test2' . PHP_EOL . ' ' . PHP_EOL . 'test3';
@@ -100,18 +109,23 @@ class Test_Offline_Form extends \WP_UnitTestCase {
 	 * @covers ::get_offline_form_script
 	 */
 	public function test_get_offline_form_script() {
+		$old_option = get_option( 'rt_pwa_extension_options' );
+
 		$expected_offline_url = home_url( '/' ) . '?wp_error_template=offline';
 		$expected_500_url     = home_url( '/' ) . '?wp_error_template=500';
 
-		$this->assertContains( $expected_offline_url, $this->_instance->get_offline_form_script() );
-		$this->assertContains( $expected_500_url, $this->_instance->get_offline_form_script() );
+		$this->assertFalse( $this->_instance->get_offline_form_script() );
 
 		$expected_form_routes = 'test1|test2|test3';
 
 		$option = 'test1' . PHP_EOL . 'test2' . PHP_EOL . 'test3';
 		update_option( 'rt_pwa_extension_options', $option );
 
+		$this->assertContains( $expected_offline_url, $this->_instance->get_offline_form_script() );
+		$this->assertContains( $expected_500_url, $this->_instance->get_offline_form_script() );
 		$this->assertContains( $expected_form_routes, $this->_instance->get_offline_form_script() );
+
+		update_option( 'rt_pwa_extension_options', $old_option );
 
 	}
 


### PR DESCRIPTION
Fixes #33 
- Fixes offline form Service worker script conflict.
- Removed generation of random string as form route and add a condition to not enqueue offline form script if the form routes are not set.